### PR TITLE
Skip a wildcard method operation

### DIFF
--- a/swagger/plugin.go
+++ b/swagger/plugin.go
@@ -157,6 +157,9 @@ func (p *Plugin) processHandler(rd *ucon.RouteDefinition) error {
 		putOperation = func(op *Operation) {
 			item.Patch = op
 		}
+	case "*":
+		// swagger.json should skip wildcard method
+		return nil
 	default:
 		return fmt.Errorf("unknown method: %s", rd.Method)
 	}

--- a/swagger/plugin_test.go
+++ b/swagger/plugin_test.go
@@ -199,6 +199,33 @@ func TestPluginProcessHandlerWithNoopStruct(t *testing.T) {
 	}
 }
 
+func TestPluginProcessHandlerWithWildcardMethod(t *testing.T) {
+	p := NewPlugin(nil)
+
+	rd := &ucon.RouteDefinition{
+		Method:       "*", // should be skipped
+		PathTemplate: ucon.ParsePathTemplate("/api/test/{id}"),
+		HandlerContainer: &handlerContainerImpl{
+			handler: func(c context.Context, _ *ReqSwaggerParameter) error {
+				return nil
+			},
+		},
+	}
+
+	err := p.processHandler(rd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v := len(p.swagger.Paths); v != 0 {
+		t.Fatalf("unexpected: %v", v)
+	}
+
+	if v := len(p.swagger.Definitions); v != 0 {
+		t.Fatalf("unexpected: %v", v)
+	}
+}
+
 type SelfRecursion struct {
 	Self *SelfRecursion
 }


### PR DESCRIPTION
Skip wildcard (`*`) method operations in swagger plugin processing
