### PR TITLE
Fix: ignore error when path parameter types are wrong

### DIFF
--- a/middleware_builtin.go
+++ b/middleware_builtin.go
@@ -138,7 +138,10 @@ func RequestObjectMapper() MiddlewareFunc {
 				return ErrInvalidPathParameterType
 			}
 			for key, value := range params {
-				valueStringMapper(reqV, key, value)
+				found, _ := valueStringMapper(reqV, key, value)
+				if !found {
+					return ErrPathParameterFieldMissing
+				}
 			}
 		}
 

--- a/middleware_builtin.go
+++ b/middleware_builtin.go
@@ -130,7 +130,7 @@ func RequestObjectMapper() MiddlewareFunc {
 		reqV := reflect.New(argT.Elem())
 		req := reqV.Interface()
 
-		// NOTE value overwrited by below process
+		// NOTE value will be overwritten by below process
 		// url path extract
 		if v := b.Context.Value(PathParameterKey); v != nil {
 			params, ok := v.(map[string]string)
@@ -138,13 +138,7 @@ func RequestObjectMapper() MiddlewareFunc {
 				return ErrInvalidPathParameterType
 			}
 			for key, value := range params {
-				found, err := valueStringMapper(reqV, key, value)
-				if err != nil {
-					return err
-				}
-				if !found {
-					return ErrPathParameterFieldMissing
-				}
+				valueStringMapper(reqV, key, value)
 			}
 		}
 

--- a/middleware_builtin_test.go
+++ b/middleware_builtin_test.go
@@ -103,6 +103,25 @@ func TestResponseMapperWithHandlerReturnsError(t *testing.T) {
 	}
 }
 
+func TestRequestObjectMapperWithWrongTypedPathParameter(t *testing.T) {
+	b, _ := MakeMiddlewareTestBed(t, RequestObjectMapper(), func(req *TargetOfRequestObjectMapper) {
+		if req.ID != 0 {
+			t.Errorf("unexpected: %v", req.ID)
+		}
+	}, &BubbleTestOption{
+		Method: "POST",
+		URL:    "/api/todo/{id}",
+		Body:   strings.NewReader("{\"text\": \"Hi!\"}"),
+	})
+	b.Context = context.WithValue(b.Context, PathParameterKey, map[string]string{
+		"id": "test", // not a number -> zero
+	})
+	err := b.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 type TargetOfResponseMapper struct {
 	ID     int    `json:"id"`
 	Offset int    `json:"offset"`

--- a/utils.go
+++ b/utils.go
@@ -85,7 +85,7 @@ func valueStringMapper(target reflect.Value, key string, value string) (bool, er
 		if ft := f.Type(); ft.AssignableTo(stringParserType) {
 			v, err := reflect.New(ft).Interface().(StringParser).ParseString(value)
 			if err != nil {
-				return false, err
+				return true, err
 			}
 			f.Set(reflect.ValueOf(v))
 			return true, nil
@@ -93,7 +93,7 @@ func valueStringMapper(target reflect.Value, key string, value string) (bool, er
 
 		err := SetValueFromString(f, value)
 		if err != nil {
-			return false, err
+			return true, err
 		}
 
 		return true, nil


### PR DESCRIPTION
BREAKING CHANGES:

Before:

```
route: /api/todo/{id}

type TodoReq struct {
  ID int64 `json:"id"`
}

/api/todo/foobar --> Bad Request : "id is not int format"
```

After: 

```
route: /api/todo/{id}

type TodoReq struct {
  ID int64 `json:"id"`
}

/api/todo/foobar --> req.ID == 0 // zero value of int64
```
