### PR TITLE
feat(validator) Add ignore type support to validator for custom DI

### DIFF
--- a/swagger/validator.go
+++ b/swagger/validator.go
@@ -44,8 +44,8 @@ func (ve *validateError) Error() string {
 }
 
 // RequestValidator checks request object validity by swagger tag.
-func RequestValidator() ucon.MiddlewareFunc {
-	return ucon.RequestValidator(DefaultValidator)
+func RequestValidator(options... *ucon.RequestValidatorOption) ucon.MiddlewareFunc {
+	return ucon.RequestValidator(DefaultValidator, options...)
 }
 
 func init() {

--- a/swagger/validator_test.go
+++ b/swagger/validator_test.go
@@ -12,10 +12,35 @@ type TargetRequestValidate struct {
 	Text string `swagger:"enum=ok|ng"`
 }
 
+type IgnoreRequestValidate struct {
+	Text string `swagger:"enum=ok|ng"`
+}
+
+
+
 func TestRequestValidator_valid(t *testing.T) {
 	b, _ := ucon.MakeMiddlewareTestBed(t, RequestValidator(), func(req *TargetRequestValidate) {
 	}, nil)
 	b.Arguments[0] = reflect.ValueOf(&TargetRequestValidate{Text: "ok"})
+
+	err := b.Next()
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+}
+
+func TestRequestValidator_validWithIgnore(t *testing.T) {
+
+	ignoreType := reflect.TypeOf((*IgnoreRequestValidate)(nil))
+	b, _ := ucon.MakeMiddlewareTestBed(t, RequestValidator(&ucon.RequestValidatorOption{IgnoreValidateFunc: func(argT reflect.Type, rv reflect.Value) bool {
+		if ignoreType.AssignableTo(argT) {
+			return true
+		}
+		return false
+	}}), func(req *TargetRequestValidate, req2 *IgnoreRequestValidate) {
+	}, nil)
+	b.Arguments[0] = reflect.ValueOf(&TargetRequestValidate{Text: "ok"})
+	b.Arguments[1] = reflect.ValueOf(&IgnoreRequestValidate{Text: "bad"})
 
 	err := b.Next()
 	if err != nil {


### PR DESCRIPTION
RequestValidator validate all arguments if custom DI object is added.
I add ignore option for custom DI object.